### PR TITLE
[MSHARED-1327] Change default value of output directory in AbstractMavenReport

### DIFF
--- a/src/it/use-as-direct-mojo-markup/verify.groovy
+++ b/src/it/use-as-direct-mojo-markup/verify.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-File outputDir = new File( basedir, 'target/site/' )
+File outputDir = new File( basedir, 'target/reports/' )
 
 File f = new File( outputDir, 'custom-report.xdoc' );
 assert f.exists();

--- a/src/it/use-as-direct-mojo/verify.groovy
+++ b/src/it/use-as-direct-mojo/verify.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-File outputDir = new File( basedir, 'target/site/' )
+File outputDir = new File( basedir, 'target/reports/' )
 
 File f = new File( outputDir, 'custom-report.html' );
 assert f.exists();

--- a/src/main/java/org/apache/maven/reporting/AbstractMavenReport.java
+++ b/src/main/java/org/apache/maven/reporting/AbstractMavenReport.java
@@ -84,7 +84,7 @@ public abstract class AbstractMavenReport extends AbstractMojo implements MavenM
      * user-defined mojo parameter with a default value) to generate multi-page reports or external reports with the
      * main output file (entry point) denoted by {@link #getOutputName()}.
      */
-    @Parameter(defaultValue = "${project.reporting.outputDirectory}", readonly = true, required = true)
+    @Parameter(defaultValue = "${project.build.directory}/reports", readonly = true, required = true)
     protected File outputDirectory;
 
     /**


### PR DESCRIPTION
The output directory now defaults to `${project.build.directory}` instead of `${project.reporting.outputDirectory}`. Quoting my reasoning from https://github.com/apache/maven-jxr/commit/ae81a34ac616bf7e4ea4fa9d4eb09f0979eaccb1#commitcomment-130639906:

> (...) because the latter is simply wrong IMO. For stand-alone mojo execution, a plugin should not mess with Maven Site's default directory. Imagine a situation in which each module should get its own, self-consistent report when called stand-alone, but the site should contain an aggregate with a different structure or maybe no report from that plugin at all. The default would then pollute the site directory. This is why on the ML I asked you (@michael-o), if overriding a `@Parameter` annotation on a base class field by another `@Parameter` annotation on a setter in a subclass it is the right or canonical way to implement such a default override.
> 
> BTW, like I also said before, Maven Javadoc Plugin, even though it does not use the abstract base class, implements the default correctly: build dir for stand-alone, report dir in site generation context.

The javadoc is, BTW, still correct and does not need to be changed: In a site generation context, the reporting base directory will be set here automatically without any further changes due to:

```java
    @Override
    public void setReportOutputDirectory(File reportOutputDirectory) {
        this.reportOutputDirectory = reportOutputDirectory;
        this.outputDirectory = reportOutputDirectory;
    }
```
