### PR TITLE
enable build with Maven 4

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
+    with:
+      maven4-enabled: true

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,3 +27,5 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
     with:
       maven4-enabled: true
+      ff-goal: verify
+      verify-goal: verify


### PR DESCRIPTION
build with Maven 4 in CI, to check if maven-reporting-impl 4.x works with Maven 4 (4.x is for Doxia 2, not for Maven 4...)

and complete the table on https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=406620656#Maven4.0.0GAchecklist-Maven4API