### PR TITLE
Depend on the released Doxia 1.12.0, not the snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
   <properties>
     <javaVersion>7</javaVersion>
     <mavenVersion>3.1.0</mavenVersion>
-    <doxiaVersion>1.12.0-SNAPSHOT</doxiaVersion>
+    <doxiaVersion>1.12.0</doxiaVersion>
     <doxiaSitetoolsVersion>1.11.1</doxiaSitetoolsVersion>
     <reportingApiVersion>3.1.1</reportingApiVersion>
     <project.build.outputTimestamp>2022-08-06T21:52:45Z</project.build.outputTimestamp>


### PR DESCRIPTION
This branch's build fails before it compiles anything:

```
[ERROR] Failed to execute goal on project maven-reporting-impl: Could not resolve dependencies
[ERROR] dependency: org.apache.maven.doxia:doxia-sink-api:jar:1.12.0-SNAPSHOT (compile)
[ERROR]   Could not find artifact org.apache.maven.doxia:doxia-sink-api:jar:1.12.0-SNAPSHOT in Nexus
```

`doxiaVersion` is still `1.12.0-SNAPSHOT`. That snapshot is long gone from the snapshot repository, and 1.12.0 was released — so this is just dropping the suffix. It is the only `-SNAPSHOT` dependency in the POM; the project's own `3.3.0-SNAPSHOT` version is untouched.

`dependency:resolve` succeeds afterwards, picking up `doxia-sink-api`, `doxia-core` and `doxia-logging-api` at 1.12.0 alongside the sitetools artifacts already pinned at 1.11.1.

I could not run a full build locally — the branch targets Java 7 and my JDK is too new (`Source option 7 is no longer supported`); CI builds it on JDK 8/11/17. Dependency resolution is the part that was failing and it is what I verified.

Heads-up for the next build: this branch is also on parent `maven-shared-components` 34, whose apache-rat 0.13 rejects the `.mvn/wrapper/maven-wrapper.properties` that the Jenkins shared library now generates. Once resolution is fixed, the build will most likely reach the RAT check and fail there. apache/maven-reporting-api#77 is the same fix for the sibling repository. Context in apache/maven#12676.