### PR TITLE
Keep verbatim blocks working with Doxia 1

### DIFF
--- a/src/main/java/org/apache/maven/reporting/AbstractMavenReportRenderer.java
+++ b/src/main/java/org/apache/maven/reporting/AbstractMavenReportRenderer.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 
 import org.apache.maven.doxia.markup.Markup;
 import org.apache.maven.doxia.sink.Sink;
+import org.apache.maven.doxia.sink.SinkEventAttributes;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.shared.utils.StringUtils;
 
@@ -343,7 +344,10 @@ public abstract class AbstractMavenReportRenderer implements MavenReportRenderer
      * @see Sink#verbatim_()
      */
     protected void verbatimText(String text) {
-        sink.verbatim();
+        // Sink.verbatim() only exists since Doxia 2, while report plugins always run against the Doxia
+        // provided by the Maven Site Plugin in use, which may still be Doxia 1. Only the attribute
+        // taking overload exists in both, so stick to it (MPIR issue 103).
+        sink.verbatim((SinkEventAttributes) null);
 
         text(text);
 
@@ -364,7 +368,8 @@ public abstract class AbstractMavenReportRenderer implements MavenReportRenderer
         if (href == null || href.isEmpty()) {
             verbatimText(text);
         } else {
-            sink.verbatim();
+            // see verbatimText(String) for why the attribute taking overload is used here
+            sink.verbatim((SinkEventAttributes) null);
 
             link(href, text);
 

--- a/src/test/java/org/apache/maven/reporting/AbstractMavenReportRendererTest.java
+++ b/src/test/java/org/apache/maven/reporting/AbstractMavenReportRendererTest.java
@@ -20,9 +20,12 @@ package org.apache.maven.reporting;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.maven.doxia.sink.Sink;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -124,5 +127,44 @@ class AbstractMavenReportRendererTest {
                     "Apache Software License, version 1.1",
                     "http://www.apache.org/licenses/LICENSE-1.1"
                 });
+    }
+
+    /**
+     * Report plugins always run against the Doxia provided by the Maven Site Plugin in use, which may still be
+     * Doxia 1, where {@code Sink.verbatim()} does not exist yet. A dynamic proxy is used instead of a
+     * {@code SinkAdapter} subclass because {@code AbstractSink.verbatim()} is final and delegates to the
+     * attribute taking overload, which would hide the distinction this test is about.
+     */
+    @Test
+    void verbatimOnlyUsesTheOverloadCommonToDoxia1And2() {
+        AtomicInteger verbatimCalls = new AtomicInteger();
+        Sink sink = (Sink) Proxy.newProxyInstance(
+                getClass().getClassLoader(), new Class<?>[] {Sink.class}, (proxy, method, args) -> {
+                    if ("verbatim".equals(method.getName())) {
+                        assertEquals(
+                                1,
+                                method.getParameterCount(),
+                                "Sink.verbatim() does not exist in Doxia 1 and must not be called");
+                        verbatimCalls.incrementAndGet();
+                    }
+                    return null;
+                });
+
+        AbstractMavenReportRenderer renderer = new AbstractMavenReportRenderer(sink) {
+            @Override
+            public String getTitle() {
+                return "title";
+            }
+
+            @Override
+            protected void renderBody() {
+                verbatimText("text");
+                verbatimLink("text", "https://maven.apache.org/");
+            }
+        };
+
+        renderer.render();
+
+        assertEquals(2, verbatimCalls.get());
     }
 }


### PR DESCRIPTION
Fixes the `NoSuchMethodError` reported in apache/maven-project-info-reports-plugin#103, which silently truncates five MPIR reports (`dependency-info`, `ci-management`, `issue-management`, `licenses`, `scm`) while the build still says SUCCESS.

### Why it happens

A report plugin never runs against its own Doxia. `DefaultMavenReportExecutor` in maven-reporting-exec imports `org.apache.maven.doxia.sink` (as a prefix, so `.impl` too) from the Maven Site Plugin realm into the report plugin realm, and excludes `doxia-sink-api` from the report plugin's own dependency resolution. Whatever Doxia the site plugin ships is what the report gets.

`Sink.verbatim()` with no argument was only added in Doxia 2. Doxia 1 has `verbatim(boolean)`, `verbatim(SinkEventAttributes)` and `verbatim_()`. So as soon as a report plugin picks up maven-reporting-impl 4.x and is rendered by a Maven Site Plugin older than 3.21.0, `verbatimText`/`verbatimLink` blow up. Maven 3.9.x still binds maven-site-plugin 3.12.1 (Doxia 1.11.1) by default, so users hit this without doing anything unusual.

### The change

Call `verbatim(SinkEventAttributes)` instead, which exists in both Doxia 1 and Doxia 2. Passing `null` is safe on either: Doxia 1's `Xhtml5BaseSink.verbatim` runs the argument through `SinkUtils.filterAttributes`, which returns `null` for `null` and is then replaced by an empty attribute set.

This is the only Doxia 2 only `Sink` method reached on the `generate(Sink, Locale)` path. I checked every `sink.` call in this component against both Doxia branches: `tableRows(int[], boolean)`, `section`, `sectionTitle`, `anchor`, `link`, `text` and `rawText` all exist in Doxia 1 as well. `AbstractMavenReport`'s Doxia 2 only imports (`DocumentRenderingContext`, `SiteModel`, `SiteRendererSink`) are confined to the standalone `execute()` path, where the site plugin realm is not involved.

### Verification

Built this branch plus MPIR against it and ran `mvn site` on a small project:

- maven-site-plugin 3.12.1 (Doxia 1.11.1): before, `NoSuchMethodError` and truncated reports; after, complete reports with the verbatim blocks rendered.
- maven-site-plugin 3.21.0 (Doxia 2.0.0): unchanged, complete reports before and after.

The added unit test drives `verbatimText` and `verbatimLink` through a `Sink` proxy that fails on the no argument overload. It fails without the production change. A dynamic proxy is used rather than a `SinkAdapter` subclass because `AbstractSink.verbatim()` is `final` and delegates to the attribute taking overload, which would mask the distinction.

### Not addressed here

`verbatimSource` still uses `SinkEventAttributeSet.SOURCE`, which is named `BOXED` in Doxia 1 and would fail the same way with a `NoSuchFieldError`. MPIR does not call it, so it is out of scope for this fix, but it is the other half of MSHARED-1364 and worth a follow up.