### PR TITLE
Support multipage reports when the goal is invoked directly

### DIFF
--- a/src/it/use-as-direct-mojo/invoker.properties
+++ b/src/it/use-as-direct-mojo/invoker.properties
@@ -18,4 +18,4 @@
 invoker.goals.1 = custom-reporting:custom
 invoker.goals.2 = custom-reporting:custom-renderer
 invoker.goals.3 = custom-reporting:external
-#invoker.goals.4 = custom-reporting:multi-page # https://github.com/apache/maven-reporting-impl/issues/217
+invoker.goals.4 = custom-reporting:multi-page

--- a/src/it/use-as-direct-mojo/verify.groovy
+++ b/src/it/use-as-direct-mojo/verify.groovy
@@ -34,10 +34,12 @@ f = new File( outputDir, 'external/report.html' );
 assert f.exists();
 assert f.text.contains( '<h1>External Report</h1>' );
 
-// https://github.com/apache/maven-reporting-impl/issues/217
-/*f = new File( outputDir, 'multi-page.html' );
+f = new File( outputDir, 'multi-page.html' );
 assert f.exists();
+assert f.text.contains( 'Custom Maven Report with Renderer content.' );
+
 f = new File( outputDir, 'multi-second.html' );
-assert f.exists();*/
+assert f.exists();
+assert f.text.contains( 'Custom Maven Report with Renderer content.' );
 
 return true;

--- a/src/main/java/org/apache/maven/reporting/AbstractMavenReport.java
+++ b/src/main/java/org/apache/maven/reporting/AbstractMavenReport.java
@@ -23,9 +23,11 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -55,6 +57,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.WriterFactory;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.util.PathTool;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -280,9 +283,10 @@ public abstract class AbstractMavenReport extends AbstractMojo implements MavenM
                     new DocumentRenderingContext(outputDirectory, getOutputPath(), reportMojoInfo);
 
             SiteRendererSink sink = new SiteRendererSink(docRenderingContext);
+            // sink factory, for multipage reports that need sub-sinks
+            MultiPageSinkFactory multiPageSinkFactory = new MultiPageSinkFactory(this, docRenderingContext);
 
-            // TODO Compared to Maven Site Plugin multipage reports will not work and fail with an NPE
-            generate(sink, null, locale);
+            generate(sink, multiPageSinkFactory, locale);
 
             if (!isExternalReport()) { // MSHARED-204: only render Doxia sink if not an external report
                 outputDirectory.mkdirs();
@@ -292,6 +296,27 @@ public abstract class AbstractMavenReport extends AbstractMojo implements MavenM
                     // render report
                     getSiteRenderer().mergeDocumentIntoSite(writer, sink, siteContext);
                 }
+
+                // render the subpages eventually created by a multipage report
+                for (MultiPageSubSink subSink : multiPageSinkFactory.sinks()) {
+                    File subOutputDirectory = subSink.getOutputDirectory();
+                    subOutputDirectory.mkdirs();
+
+                    // the directory comes from the report, so make sure it is absolute before relativizing it
+                    File subOutputFile = new File(subOutputDirectory, subSink.getOutputName());
+                    getLog().info("Rendering report to "
+                            + getProject()
+                                    .getBasedir()
+                                    .toPath()
+                                    .relativize(subOutputFile.toPath().toAbsolutePath()));
+
+                    try (Writer writer =
+                            new OutputStreamWriter(new FileOutputStream(subOutputFile), getOutputEncoding())) {
+                        getSiteRenderer().mergeDocumentIntoSite(writer, subSink, siteContext);
+                    } finally {
+                        subSink.close();
+                    }
+                }
             }
 
             // copy generated resources also
@@ -299,6 +324,97 @@ public abstract class AbstractMavenReport extends AbstractMojo implements MavenM
         } catch (RendererException | IOException | MavenReportException | SiteToolException e) {
             throw new MojoExecutionException(
                     "An error has occurred in " + getName(Locale.ENGLISH) + " report generation.", e);
+        }
+    }
+
+    /**
+     * A sink for one subpage of a multipage report, remembering where it is meant to be written to.
+     */
+    private static class MultiPageSubSink extends SiteRendererSink {
+        private final File outputDirectory;
+
+        private final String outputName;
+
+        MultiPageSubSink(File outputDirectory, String outputName, DocumentRenderingContext docRenderingContext) {
+            super(docRenderingContext);
+            this.outputDirectory = outputDirectory;
+            this.outputName = outputName;
+        }
+
+        String getOutputName() {
+            return outputName;
+        }
+
+        File getOutputDirectory() {
+            return outputDirectory;
+        }
+    }
+
+    /**
+     * The sink factory handed to {@link #generate(Sink, SinkFactory, Locale)}, mirroring what Maven Site Plugin
+     * provides so that a multipage report behaves the same when its goal is invoked directly.
+     */
+    private static class MultiPageSinkFactory implements SinkFactory {
+        /**
+         * The report that is (maybe) generating multiple pages
+         */
+        private final MavenReport report;
+
+        /**
+         * The main DocumentRenderingContext, which is the base for the DocumentRenderingContext of subpages
+         */
+        private final DocumentRenderingContext docRenderingContext;
+
+        /**
+         * List of sinks (subpages) associated to this report
+         */
+        private final List<MultiPageSubSink> sinks = new ArrayList<>();
+
+        MultiPageSinkFactory(MavenReport report, DocumentRenderingContext docRenderingContext) {
+            this.report = report;
+            this.docRenderingContext = docRenderingContext;
+        }
+
+        @Override
+        public Sink createSink(File outputDirectory, String outputName) {
+            // Create a new document rendering context, similar to the main one, but with a different output name
+            String document = PathTool.getRelativeFilePath(
+                    report.getReportOutputDirectory().getPath(), new File(outputDirectory, outputName).getPath());
+            // Remove .html suffix since we know that we are in Site Renderer context
+            document = document.substring(0, document.lastIndexOf('.'));
+
+            DocumentRenderingContext subSinkContext = new DocumentRenderingContext(
+                    docRenderingContext.getBasedir(), document, docRenderingContext.getGenerator());
+
+            // Create a sink for this subpage, based on this new document rendering context
+            MultiPageSubSink sink = new MultiPageSubSink(outputDirectory, outputName, subSinkContext);
+
+            // Add it to the list of sinks associated to this report
+            sinks.add(sink);
+
+            return sink;
+        }
+
+        @Override
+        public Sink createSink(File outputDir, String outputName, String encoding) {
+            throw new UnsupportedOperationException(
+                    "Only createSink(File, String) is supported by MultiPageSinkFactory. The encoding is always determined by the site rendering context.");
+        }
+
+        @Override
+        public Sink createSink(OutputStream out) {
+            throw new UnsupportedOperationException(
+                    "Only createSink(File, String) is supported by MultiPageSinkFactory. OutputStream based sinks are not supported.");
+        }
+
+        @Override
+        public Sink createSink(OutputStream out, String encoding) {
+            throw new UnsupportedOperationException(
+                    "Only createSink(File, String) is supported by MultiPageSinkFactory. OutputStream based sinks are not supported.");
+        }
+
+        List<MultiPageSubSink> sinks() {
+            return sinks;
         }
     }
 


### PR DESCRIPTION
Fixes #217.

`reportToSite()` passed `null` as the `SinkFactory` to `generate(Sink, SinkFactory, Locale)`, with a TODO saying multipage reports would fail with an NPE. They do:

```
mvn plugin-report:3.15.1:report
...
Cannot invoke "org.apache.maven.doxia.sink.SinkFactory.createSink(java.io.File, String)"
because the return value of "PluginReport.getSinkFactory()" is null
    at PluginReport.generateMojosDocumentation (PluginReport.java:280)
    at AbstractMavenReport.reportToSite (AbstractMavenReport.java:266)
```

Only the site path was affected. `reportToMarkup()`, taken when `output.format` is set, already builds a sink factory, which is why `use-as-direct-mojo-markup` exercises the multi-page mojo happily while `use-as-direct-mojo` could not.

### The change

Hand `generate()` a `MultiPageSinkFactory` mirroring the one in Maven Site Plugin's `ReportDocumentRenderer`: each `createSink(File, String)` builds a `DocumentRenderingContext` derived from the main one, wraps it in a `SiteRendererSink` that remembers where it belongs, and records it. After the main document is merged into the site, every collected sub-sink is merged the same way.

Keeping the structure identical to `ReportDocumentRenderer` is deliberate, so the two stay easy to compare, and so a report behaves the same whether its goal is invoked directly or through the site.

### Test

The integration test for exactly this was already written and disabled with a pointer to the issue, in `src/it/use-as-direct-mojo`. This PR enables `invoker.goals.4 = custom-reporting:multi-page` again and uncomments the `verify.groovy` assertions, extended to also check the rendered content rather than mere file existence.

I confirmed it is a real regression guard: reverting only `AbstractMavenReport` and rerunning the IT reproduces the reported failure.

```
Cannot invoke "org.apache.maven.doxia.sink.SinkFactory.createSink(java.io.File, String)"
because the return value of "MultiPageReport.getSinkFactory()" is null
Passed: 1, Failed: 1
```

With the change, `mvn verify` is green over the full IT suite (6 passed), and the multipage goal logs both pages:

```
--- custom-reporting:1.0-SNAPSHOT:multi-page (default-cli) @ use-as-direct-mojo ---
Rendering report to target/reports/multi-page.html
          using org.apache.maven.skins:maven-fluido-skin:jar:2.0.0-M9 site skin
Rendering report to target/reports/multi-second.html
```

I did not rebuild maven-plugin-report-plugin against this branch to re-verify the original report from the issue; the IT covers the same code path with the same API.