### PR TITLE
Keep verbatim source blocks working with Doxia 1

### DIFF
--- a/src/main/java/org/apache/maven/reporting/AbstractMavenReportRenderer.java
+++ b/src/main/java/org/apache/maven/reporting/AbstractMavenReportRenderer.java
@@ -386,7 +386,11 @@ public abstract class AbstractMavenReportRenderer implements MavenReportRenderer
      * @see Sink#verbatim_()
      */
     protected void verbatimSource(String source) {
-        sink.verbatim(SinkEventAttributeSet.SOURCE);
+        // not SinkEventAttributeSet.SOURCE: that constant only exists since Doxia 2, where it replaced BOXED,
+        // and report plugins run against the Doxia the Maven Site Plugin provides, which may still be Doxia 1.
+        // Building the same attribute set by hand keeps this a plain verbatim block there instead of a
+        // NoSuchFieldError (MPIR issue 103 was the same problem one method over).
+        sink.verbatim(new SinkEventAttributeSet(SinkEventAttributes.DECORATION, "source"));
 
         text(source);
 

--- a/src/test/java/org/apache/maven/reporting/AbstractMavenReportRendererTest.java
+++ b/src/test/java/org/apache/maven/reporting/AbstractMavenReportRendererTest.java
@@ -21,14 +21,18 @@ package org.apache.maven.reporting;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.maven.doxia.sink.Sink;
+import org.apache.maven.doxia.sink.SinkEventAttributes;
+import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -166,5 +170,45 @@ class AbstractMavenReportRendererTest {
         renderer.render();
 
         assertEquals(2, verbatimCalls.get());
+    }
+
+    /**
+     * Same reasoning for {@code verbatimSource}, one level down: the attribute set has to be built rather than
+     * read off {@code SinkEventAttributeSet.SOURCE}, which is only there since Doxia 2. Asserting the identity
+     * rather than only the content is what makes this fail if the constant is used again, since the constant
+     * carries exactly the same attribute.
+     */
+    @Test
+    void verbatimSourceBuildsTheAttributeSetRatherThanReadingTheDoxia2Constant() {
+        List<SinkEventAttributes> verbatimAttributes = new ArrayList<>();
+        Sink sink = (Sink) Proxy.newProxyInstance(
+                getClass().getClassLoader(), new Class<?>[] {Sink.class}, (proxy, method, args) -> {
+                    if ("verbatim".equals(method.getName()) && method.getParameterCount() == 1) {
+                        verbatimAttributes.add((SinkEventAttributes) args[0]);
+                    }
+                    return null;
+                });
+
+        AbstractMavenReportRenderer renderer = new AbstractMavenReportRenderer(sink) {
+            @Override
+            public String getTitle() {
+                return "title";
+            }
+
+            @Override
+            protected void renderBody() {
+                verbatimSource("var code = true;");
+            }
+        };
+
+        renderer.render();
+
+        assertEquals(1, verbatimAttributes.size());
+        SinkEventAttributes attributes = verbatimAttributes.get(0);
+        assertEquals("source", attributes.getAttribute(SinkEventAttributes.DECORATION));
+        assertNotSame(
+                SinkEventAttributeSet.SOURCE,
+                attributes,
+                "SinkEventAttributeSet.SOURCE does not exist in Doxia 1 and must not be read");
     }
 }


### PR DESCRIPTION
Finishes what #243 started. That PR fixed `verbatimText` and `verbatimLink`, and called out `verbatimSource` as the remaining half; this is it.

`SinkEventAttributeSet.SOURCE` arrived in Doxia 2, where DOXIA-685 introduced it in place of `BOXED`. Reading it therefore ends in a `NoSuchFieldError` whenever the Maven Site Plugin in use still provides Doxia 1, since a report plugin renders with the Doxia the Site Plugin provides rather than its own. Maven 3.9.x still binds maven-site-plugin 3.12.1 by default, so that is the common case rather than an exotic one.

Unlike the `verbatim()` case, this one is not reachable from maven-project-info-reports-plugin, which is why apache/maven-project-info-reports-plugin#103 only ever showed the other symptom. It is reachable though: `PluginOverviewRenderer` in maven-plugin-report-plugin calls `verbatimSource`.

### The change

Build the attribute set rather than reading the constant:

```java
sink.verbatim(new SinkEventAttributeSet(SinkEventAttributes.DECORATION, "source"));
```

`SinkEventAttributes.DECORATION` and the varargs constructor both exist in Doxia 1 and Doxia 2, and `DECORATION` is a compile time String constant, so nothing here is resolved against a class that might be missing.

Output is unchanged on Doxia 2: the constant holds exactly this attribute, and the existing integration test still asserts `<pre class="prettyprint"><code>…</code></pre>`. On Doxia 1 the decoration value `source` is simply not one it recognises, so the block renders as a plain verbatim block. Losing the styling there is a lot better than losing the report.

Note this leaves #184 open, since building the set still needs `SinkEventAttributeSet` from the `impl` package. That is a packaging problem, waiting on apache/maven-doxia#1073; this is a Doxia 1 versus 2 problem, and the two are independent.

### Test

The new test asserts both the attribute value and, with `assertNotSame`, that the set is not the constant itself. The identity check is the part that matters: content alone would pass either way, since the constant carries the same attribute. Reverting the production change fails it:

```
SinkEventAttributeSet.SOURCE does not exist in Doxia 1 and must not be read ==> expected: not same but was: < decoration=source>
```

`mvn verify` green: unit tests, all 6 ITs, and rat.
